### PR TITLE
Tf 24 fix sprint spam slowdown

### DIFF
--- a/Assets/Input/PlayerInput.cs
+++ b/Assets/Input/PlayerInput.cs
@@ -155,7 +155,7 @@ public partial class @PlayerInput : IInputActionCollection2, IDisposable
                     ""name"": """",
                     ""id"": ""4b9adc94-d9f5-462f-ba63-cf0897e1f232"",
                     ""path"": ""<Keyboard>/leftShift"",
-                    ""interactions"": ""Hold(duration=0.1)"",
+                    ""interactions"": ""Hold(duration=0.001)"",
                     ""processors"": """",
                     ""groups"": """",
                     ""action"": ""Sprint"",

--- a/Assets/Input/PlayerInput.inputactions
+++ b/Assets/Input/PlayerInput.inputactions
@@ -133,7 +133,7 @@
                     "name": "",
                     "id": "4b9adc94-d9f5-462f-ba63-cf0897e1f232",
                     "path": "<Keyboard>/leftShift",
-                    "interactions": "Hold(duration=0.1)",
+                    "interactions": "Hold(duration=0.001)",
                     "processors": "",
                     "groups": "",
                     "action": "Sprint",

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -9846,6 +9846,7 @@ MonoBehaviour:
   speed: 5
   sprintMult: 2
   gravity: 9.8
+  drag: 0.999
   jumpHeight: 1
 --- !u!114 &1317864897
 MonoBehaviour:
@@ -9925,7 +9926,7 @@ MonoBehaviour:
     ModeOverride: 0
     LensShift: {x: 0, y: 0}
     GateFit: 2
-    m_SensorSize: {x: 1.8917526, y: 1}
+    m_SensorSize: {x: 1.9395162, y: 1}
   m_Transitions:
     m_BlendHint: 0
     m_InheritPosition: 0
@@ -9986,7 +9987,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh25122
+  m_Name: pb_Mesh43180
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2


### PR DESCRIPTION
As the commit says I reduced the hold delay for the sprint, making the spamming a non issue(at least as far as I can spam my key).